### PR TITLE
Update the way usb_camera name is parsed.

### DIFF
--- a/src/device_agent.py
+++ b/src/device_agent.py
@@ -709,7 +709,10 @@ def get_sensor():
         parts = output.split(" ")
         # Extracted video device file name copied to dev_num variable
         dev_num = parts[6]
-        dev_no = dev_num.replace("/dev/", "")
+        # Get actual device id
+        dev_no = os.readlink(dev_num)
+        dev_no = dev_no.strip()
+        dev_no = dev_no.replace("/dev/", "")
         # Extract sensor name
         usb_name = subprocess.Popen(
             "cat /sys/class/video4linux/{}/name".format(dev_no),

--- a/src/vstream_thread.py
+++ b/src/vstream_thread.py
@@ -99,8 +99,7 @@ def run_loop(dev_num, config, stream_type, name=""):
                 ws2.send(json.dumps(infer_param))
 
             # check usb cam's availability during streaming by checking if video device file is present or not
-            path = "/sys/class/video4linux/"
-            if os.path.exists(os.path.join(path, dev_num)):
+            if os.path.exists(dev_num):
                 status = "AVAILABLE"
                 ws3.send(status)
                 time.sleep(0.1)
@@ -122,8 +121,7 @@ def run_loop(dev_num, config, stream_type, name=""):
 
         while True:
             # check usb cam's availability during streaming by checking if video device file is present or not
-            path = "/sys/class/video4linux/"
-            if os.path.exists(os.path.join(path, dev_num)):
+            if os.path.exists(dev_num):
                 status = "AVAILABLE"
                 ws3.send(status)
                 time.sleep(0.1)


### PR DESCRIPTION
usb_name was parsed using /sys/class/video4linux/device_id/name device_id was directly read from setup_camera script. In SDK 9.0 device_id printed with setup_camera script changed so to get name we need to read from actual device id. Device id printed using setup_script is softlinked to actual device id. For ex: /dev/video-usb-cam0 -> /dev/video2

Also remove redundant check for usbcam_status