### PR TITLE
run.sh: Kill seva-launcher in am62x and am62p

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,8 @@
 
 EDGEAI_STUDIO_AGENT_PATH=$(dirname "$(readlink -f "$BASH_SOURCE")")
 
+systemctl stop seva-launcher &> /dev/null
+
 if [ "$SOC" == "" ]; then
     cd /opt/edgeai-gst-apps
     source ./init_script.sh


### PR DESCRIPTION
Kill seva-launcher in am62x and am62p as it clashes with udp port 8000